### PR TITLE
Now PHP5.5 compatible (changed all <? to <?php)

### DIFF
--- a/install/functions.php
+++ b/install/functions.php
@@ -15,7 +15,7 @@ function helpdeskz_header(){
     <div id="wrapper">
     <div id="logo"></div>
     <div class="login_box">
-<?
+<?php
 }
 function helpdeskz_footer(){
     ?>
@@ -26,6 +26,6 @@ function helpdeskz_footer(){
     </div>
     </body>
     </html>
-    <?
+    <?php
     exit;
 }

--- a/install/index.php
+++ b/install/index.php
@@ -18,6 +18,6 @@ helpdeskz_header();
         <button onclick="location.href='./install.php';">Install a fresh copy</button>
         <button onclick="location.href='./upgrade.php';">Upgrade my HelpDeskZ</button>
     </div>
-<?
+<?php
 helpdeskz_footer();
 ?>

--- a/install/install.php
+++ b/install/install.php
@@ -332,7 +332,7 @@ function helpdeskz_agreement(){
 	<input type="submit" value="Continue" />
 
         </form>
-<?
+<?php
 	helpdeskz_footer();
 }
 
@@ -498,7 +498,7 @@ function helpdeskz_database($error_msg =null){
         </tr>
 		</table>
     </form>
-    <?
+    <?php
 	helpdeskz_footer();	
 }
 
@@ -508,7 +508,7 @@ function helpdeskz_completed(){
 	<h3>Installation Completed</h3>
     <p>Installation has been successfully completed, <strong>do not forget to remove</strong> <strong style="color:red">/install</strong> folder</p>
     <p><a href="../?v=staff" target="_blank">Click here to open staff panel</a></p>
-<?
+<?php
 	helpdeskz_footer();	
 }
 if($input->p['license'] == 'agree'){


### PR DESCRIPTION
This fixes an issue where HelpDeskZ would refuse to install or run on PHP 5.5, complaining about "unexpected end of file" in multiple spots (no other versions of PHP were tested)